### PR TITLE
♻️(srt) change how captions are split for srt format

### DIFF
--- a/lib/format/srt.js
+++ b/lib/format/srt.js
@@ -40,7 +40,7 @@ var helper = {
 function parse(content, options) {
   var captions = [];
   var eol = options.eol || '\r\n';
-  var parts = content.split(/\r?\n\s+\r?\n/g);
+  var parts = content.split(/\r?\n\s?\r?\n/g);
   for (var i = 0; i < parts.length; i++) {
     var regex = /^(\d+)\r?\n(\d{1,2}:\d{1,2}:\d{1,2}([.,]\d{1,3})?)\s*\-\-\>\s*(\d{1,2}:\d{1,2}:\d{1,2}([.,]\d{1,3})?)\r?\n([\s\S]*)(\r?\n)*$/gi;
     var match = regex.exec(parts[i]);

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,12 +3,22 @@ var subsrt = require('../lib/subsrt.js');
 
 exports['Parse'] = function(test) {
   var formats = subsrt.list();
+
+  var expectedCaptions = {
+    srt: 5,
+    vtt: 9,
+  };
+
   for (var i = 0; i < formats.length; i++) {
     var ext = formats[i];
     console.log('Parse .' + ext);
     var content = fs.readFileSync('./test/fixtures/sample.' + ext, 'utf8');
     var captions = subsrt.parse(content, { format: ext });
     test.ok(captions.length, 'Expected length > 0');
+
+    if (expectedCaptions[ext]) {
+      test.equal(captions.length, expectedCaptions[ext]);
+    }
 
     if (fs.existsSync('./test/output')) {
       fs.writeFileSync(


### PR DESCRIPTION
## Purpose

Some srt files does not have whitespace character between each caption
and the regex spliting the file in captions expect at least one.
Changing it by 0 or multiple whitespace character fix the issue.

## Proposal

- [x] update regex spliting srt files in captions.