### PR TITLE
✨Remove byte-order-marks at the beginning of content

### DIFF
--- a/lib/subsrt.js
+++ b/lib/subsrt.js
@@ -70,6 +70,10 @@ subsrt.detect = function(content) {
  ******************************************************************************************/
 subsrt.parse = function(content, options) {
   options = options || {};
+
+  // Remove Byte-order-marks that could appear at the beginning of a file and break our parsing
+  content = content.replace(/^\uFEFF/g, '');
+
   var format = options.format || subsrt.detect(content);
   if (!format || format.trim().length == 0) {
     throw new Error('Cannot determine subtitle format!');


### PR DESCRIPTION
### Purpose 

Byte-order-marks break parsing as it is implemented in this library.

When a developer uses a naïve approach and simply opens a file, reads it and converts it to a string, a byte-order-mark will still be present in the string (if there was one in the file), and potentially break parsing and/or result in broken outputs.

### Proposal

One could argue stripping the BOM is a responsibility of the developer reading the file.

In our opinion, we don't see potential scenarios where we could break anything by removing it brefore parsing in this library, and it makes for a more robust and vastly better experience, if it can help other users of `subsrt` avoid spending hours tracking this down (as we have 😔)

Hence, we're just removing `\uFEFF` from contents before parsing, but only if it's the first character in the content (a forgotten BOM).