### PR TITLE
🐛(VTT) remove usage of caption.index to build VTT format

### DIFF
--- a/lib/format/vtt.js
+++ b/lib/format/vtt.js
@@ -97,6 +97,7 @@ function parse(content, options) {
 function build(captions, options) {
   var eol = options.eol || '\r\n';
   var content = 'WEBVTT' + eol + eol;
+  var captionLines = 0;
   for (var i = 0; i < captions.length; i++) {
     var caption = captions[i];
     if (caption.type == 'meta') {
@@ -108,7 +109,7 @@ function build(captions, options) {
     }
 
     if (typeof caption.type === 'undefined' || caption.type == 'caption') {
-      content += caption.index.toString() + eol;
+      content += (++captionLines).toString() + eol;
       content +=
         helper.toTimeString(caption.start) +
         ' --> ' +


### PR DESCRIPTION
## Purpose

The caption.index property was used to build VTT subtitle. This property
is not set from all formats, some are not adding it and it seems quite
difficult to add it. We choose to remove the usage of caption.index and
compute this index inside the VTT build function.

## Proposal

- [x] remove usage of caption.index to build VTT format